### PR TITLE
Modify the code to handle cards with no associated usernames

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -54,6 +54,10 @@ impl Person {
                 .unwrap();
             let ids: Result<Vec<_>, _> = ids.collect();
             let ids = ids.unwrap();
+            assert!(
+                ids.len() != 0,
+                "Failed to load IDs of user. Should never happen."
+            );
             (username, ids)
         } else {
             (uid.to_string(), vec![uid])


### PR DESCRIPTION
## Problem

Hvis kortet ikke hadde brukernavn bruker man bare kortnummeret som string. Det er greit når man ser på. 

Meen for å håndtere flere kort på samme bruker, henter den alle kort som er koblet til det gitte brukernavnet. For kortnummer-brukernavn er dette INGEN, så listen over IDer ble tom. Når den tomme lista senere ble brukt til å hente statistikk fant man naturligvis ingen data, og alt falt sammen.

## Løsning

Hvis det ikke finnes noe brukernavn til kortet: bare bruk det ene kortnummeret